### PR TITLE
修复TAINT_CV 在5.5下的定义错误

### DIFF
--- a/php_taint.h
+++ b/php_taint.h
@@ -113,7 +113,7 @@ extern zend_module_entry taint_module_entry;
 
 #if (PHP_MAJOR_VERSION == 5) && (PHP_MINOR_VERSION == 5)
 #define TAINT_T(offset) (*EX_TMP_VAR(execute_data, offset))
-#define TAINT_CV(i)     (*EX_CV_NUM(execute_data, var))
+#define TAINT_CV(i)     (*EX_CV_NUM(execute_data, i))
 #define TAINT_CV_OF(i)   (*EX_CV_NUM(EG(current_execute_data), i))
 #define TAINT_PZVAL_LOCK(z)  Z_ADDREF_P((z))
 #else


### PR DESCRIPTION
修复TAINT_CV在php5.5下宏定义的错误。

虽然这个TAINT_CV 没有用到。